### PR TITLE
Added fallback to item Metadata.xml when values are not provided in input CSV file

### DIFF
--- a/AssessmentPackageBuilder.Test/Utilities/BPElementUtilitiesTest.cs
+++ b/AssessmentPackageBuilder.Test/Utilities/BPElementUtilitiesTest.cs
@@ -7,19 +7,20 @@ namespace AssessmentPackageBuilder.Test.Utilities
     [TestFixture]
     public class BpElementUtilitiesTest
     {
+
         [Test]
         public void GetBprefsBadReturnsEmptyList()
         {
             // Arrange
             const string input = "wormhole";
+            const string publisher = "SBAC_PT";
 
             // Act
-            var result = BpElementUtilities.GetBprefs(input);
+            var result = BpElementUtilities.GetBprefs(input, publisher);
 
             //Assert
             Assert.IsNotNull(result);
             Assert.IsEmpty(result);
-            ;
         }
 
         [Test]
@@ -27,17 +28,17 @@ namespace AssessmentPackageBuilder.Test.Utilities
         {
             // Arrange
             const string input = "SBAC-SH-v1:SH-Undesignated";
+            const string publisher = "SBAC_PT";
 
             // Act
-            var result = BpElementUtilities.GetBprefs(input);
+            var result = BpElementUtilities.GetBprefs(input, publisher);
 
             //Assert
             Assert.IsNotNull(result);
             Assert.IsNotEmpty(result);
-            Assert.AreEqual(result.Count, 2);
+            Assert.AreEqual(result.Count, 1);
             Assert.AreEqual(result[0].Name.LocalName, "bpref");
-            Assert.IsTrue(result[0].Value.Equals("SBAC-1", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(result[1].Value.Equals("SBAC-1|SH-Undesignated", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[0].Value.Equals("SBAC_PT-SH-Undesignated", StringComparison.OrdinalIgnoreCase));
         }
 
         [Test]
@@ -45,17 +46,17 @@ namespace AssessmentPackageBuilder.Test.Utilities
         {
             // Arrange
             const string input = "SBAC-ELA-v1:2-W";
+            const string publisher = "SBAC_PT";
 
             // Act
-            var result = BpElementUtilities.GetBprefs(input);
+            var result = BpElementUtilities.GetBprefs(input, publisher);
 
             //Assert
             Assert.IsNotNull(result);
             Assert.IsNotEmpty(result);
-            Assert.AreEqual(result.Count, 2);
+            Assert.AreEqual(result.Count, 1);
             Assert.AreEqual(result[0].Name.LocalName, "bpref");
-            Assert.IsTrue(result[0].Value.Equals("SBAC-1", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(result[1].Value.Equals("SBAC-1|2-W", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[0].Value.Equals("SBAC_PT-2-W", StringComparison.OrdinalIgnoreCase));
         }
 
         [Test]
@@ -63,18 +64,18 @@ namespace AssessmentPackageBuilder.Test.Utilities
         {
             // Arrange
             const string input = "SBAC-ELA-v1:2-W|1-3";
+            const string publisher = "SBAC_PT";
 
             // Act
-            var result = BpElementUtilities.GetBprefs(input);
+            var result = BpElementUtilities.GetBprefs(input, publisher);
 
             //Assert
             Assert.IsNotNull(result);
             Assert.IsNotEmpty(result);
-            Assert.AreEqual(result.Count, 3);
+            Assert.AreEqual(result.Count, 2);
             Assert.AreEqual(result[0].Name.LocalName, "bpref");
-            Assert.IsTrue(result[0].Value.Equals("SBAC-1", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(result[1].Value.Equals("SBAC-1|2-W", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(result[2].Value.Equals("SBAC-1|2-W|1-3", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[0].Value.Equals("SBAC_PT-2-W", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[1].Value.Equals("SBAC_PT-2-W|1-3", StringComparison.OrdinalIgnoreCase));
         }
 
         [Test]
@@ -82,21 +83,40 @@ namespace AssessmentPackageBuilder.Test.Utilities
         {
             // Arrange
             const string input = "SBAC-ELA-v1:2-W|1-3|G|6|R2D2|L-5";
+            const string publisher = "SBAC_PT";
 
             // Act
-            var result = BpElementUtilities.GetBprefs(input);
+            var result = BpElementUtilities.GetBprefs(input, publisher);
 
             //Assert
             Assert.IsNotNull(result);
             Assert.IsNotEmpty(result);
-            Assert.AreEqual(result.Count, 7);
-            Assert.IsTrue(result[0].Value.Equals("SBAC-1", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(result[1].Value.Equals("SBAC-1|2-W", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(result[2].Value.Equals("SBAC-1|2-W|1-3", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(result[3].Value.Equals("SBAC-1|2-W|1-3|G", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(result[4].Value.Equals("SBAC-1|2-W|1-3|G|6", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(result[5].Value.Equals("SBAC-1|2-W|1-3|G|6|R2D2", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(result[6].Value.Equals("SBAC-1|2-W|1-3|G|6|R2D2|L-5", StringComparison.OrdinalIgnoreCase));
+            Assert.AreEqual(result.Count, 6);
+            Assert.IsTrue(result[0].Value.Equals("SBAC_PT-2-W", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[1].Value.Equals("SBAC_PT-2-W|1-3", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[2].Value.Equals("SBAC_PT-2-W|1-3|G", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[3].Value.Equals("SBAC_PT-2-W|1-3|G|6", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[4].Value.Equals("SBAC_PT-2-W|1-3|G|6|R2D2", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[5].Value.Equals("SBAC_PT-2-W|1-3|G|6|R2D2|L-5", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Test]
+        public void GetBprefsGoodStandardWithDotsReturnsValidGroups()
+        {
+            // Arrange
+            const string input = "SBAC-ELA-v1:1-LT|7-3|3.L.5a";
+            const string publisher = "SBAC_PT";
+
+            // Act
+            var result = BpElementUtilities.GetBprefs(input, publisher);
+
+            //Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotEmpty(result);
+            Assert.AreEqual(result.Count, 3);
+            Assert.IsTrue(result[0].Value.Equals("SBAC_PT-1-LT", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[1].Value.Equals("SBAC_PT-1-LT|7-3", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[2].Value.Equals("SBAC_PT-1-LT|7-3|3.L.5a", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/AssessmentPackageBuilder.Test/Utilities/BPElementUtilitiesTest.cs
+++ b/AssessmentPackageBuilder.Test/Utilities/BPElementUtilitiesTest.cs
@@ -7,7 +7,6 @@ namespace AssessmentPackageBuilder.Test.Utilities
     [TestFixture]
     public class BpElementUtilitiesTest
     {
-
         [Test]
         public void GetBprefsBadReturnsEmptyList()
         {
@@ -79,6 +78,25 @@ namespace AssessmentPackageBuilder.Test.Utilities
         }
 
         [Test]
+        public void GetBprefsGoodStandardWithDotsReturnsValidGroups()
+        {
+            // Arrange
+            const string input = "SBAC-ELA-v1:1-LT|7-3|3.L.5a";
+            const string publisher = "SBAC_PT";
+
+            // Act
+            var result = BpElementUtilities.GetBprefs(input, publisher);
+
+            //Assert
+            Assert.IsNotNull(result);
+            Assert.IsNotEmpty(result);
+            Assert.AreEqual(result.Count, 3);
+            Assert.IsTrue(result[0].Value.Equals("SBAC_PT-1-LT", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[1].Value.Equals("SBAC_PT-1-LT|7-3", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(result[2].Value.Equals("SBAC_PT-1-LT|7-3|3.L.5a", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Test]
         public void GetBprefsGoodStandardWithSinglesReturnsValidGroups()
         {
             // Arrange
@@ -98,25 +116,6 @@ namespace AssessmentPackageBuilder.Test.Utilities
             Assert.IsTrue(result[3].Value.Equals("SBAC_PT-2-W|1-3|G|6", StringComparison.OrdinalIgnoreCase));
             Assert.IsTrue(result[4].Value.Equals("SBAC_PT-2-W|1-3|G|6|R2D2", StringComparison.OrdinalIgnoreCase));
             Assert.IsTrue(result[5].Value.Equals("SBAC_PT-2-W|1-3|G|6|R2D2|L-5", StringComparison.OrdinalIgnoreCase));
-        }
-
-        [Test]
-        public void GetBprefsGoodStandardWithDotsReturnsValidGroups()
-        {
-            // Arrange
-            const string input = "SBAC-ELA-v1:1-LT|7-3|3.L.5a";
-            const string publisher = "SBAC_PT";
-
-            // Act
-            var result = BpElementUtilities.GetBprefs(input, publisher);
-
-            //Assert
-            Assert.IsNotNull(result);
-            Assert.IsNotEmpty(result);
-            Assert.AreEqual(result.Count, 3);
-            Assert.IsTrue(result[0].Value.Equals("SBAC_PT-1-LT", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(result[1].Value.Equals("SBAC_PT-1-LT|7-3", StringComparison.OrdinalIgnoreCase));
-            Assert.IsTrue(result[2].Value.Equals("SBAC_PT-1-LT|7-3|3.L.5a", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/AssessmentPackageBuilder/Common/ItemPool.cs
+++ b/AssessmentPackageBuilder/Common/ItemPool.cs
@@ -9,7 +9,7 @@ namespace AssessmentPackageBuilder.Common
 {
     public static class ItemPool
     {
-        public static XElement Construct(IEnumerable<Item> itemInput)
+        public static XElement Construct(IEnumerable<Item> itemInput, string publisher)
         {
             var result = new XElement("itempool");
             result.Add(ExtractionSettings.ItemInput.Select(
@@ -17,7 +17,7 @@ namespace AssessmentPackageBuilder.Common
                 .Select(
                     x =>
                         TestItem.Construct(x.Content,
-                            ItemStimuliMapper.Map(x.Content, itemInput.First(y => y.ItemId.Equals(x.ItemId))))));
+                            ItemStimuliMapper.Map(x.Content, itemInput.First(y => y.ItemId.Equals(x.ItemId))), publisher)));
             result.Add(itemInput
                 .Where(x => !string.IsNullOrEmpty(x.AssociatedStimuliId)).Select(x => x.AssociatedStimuliId)
                 .Distinct()

--- a/AssessmentPackageBuilder/Common/TestItem.cs
+++ b/AssessmentPackageBuilder/Common/TestItem.cs
@@ -11,7 +11,7 @@ namespace AssessmentPackageBuilder.Common
 {
     public static class TestItem
     {
-        public static XElement Construct(AssessmentContent assessmentContent, Item itemInput)
+        public static XElement Construct(AssessmentContent assessmentContent, Item itemInput, string publisher)
         {
             var itemElement = assessmentContent.MainDocument.XPathSelectElement("/itemrelease/item");
             var uniqueId = $"{itemElement.Attribute("bankkey")?.Value}-{itemElement.Attribute("id")?.Value}";
@@ -33,7 +33,7 @@ namespace AssessmentPackageBuilder.Common
             }
             result.Add(assessmentContent.MetaDocument.XPathSelectElements(
                     "metadata/sa:smarterAppMetadata/sa:StandardPublication/sa:PrimaryStandard", sXmlNs)
-                .Select(x => BpElementUtilities.GetBprefs(x.Value)));
+                .Select(x => BpElementUtilities.GetBprefs(x.Value, publisher)));
             result.Add(new XElement("bpref", itemInput.SegmentId));
             result.Add(itemElement.XPathSelectElements("//content[@name='language']/@value")
                 .Select(x => PoolProperty.Construct("Language", x.Value)));

--- a/AssessmentPackageBuilder/Common/TestSpecification.cs
+++ b/AssessmentPackageBuilder/Common/TestSpecification.cs
@@ -16,7 +16,7 @@ namespace AssessmentPackageBuilder.Common
         {
             var result = new List<XElement>();
             var scoringRules = ScoringRules.Construct(ExtractionSettings.AssessmentScoring);
-            var itemPool = ItemPool.Construct(ExtractionSettings.ItemInput);
+            var itemPool = ItemPool.Construct(ExtractionSettings.ItemInput, ExtractionSettings.AssessmentInfo.Publisher);
             var testBlueprint = TestBlueprint.Construct(ExtractionSettings.ItemInput, itemPool,
                 ExtractionSettings.AssessmentInfo.UniqueId);
             var testForms = TestForm.Construct(ExtractionSettings.ItemInput, itemPool,

--- a/AssessmentPackageBuilder/Utilities/BPElementUtilities.cs
+++ b/AssessmentPackageBuilder/Utilities/BPElementUtilities.cs
@@ -1,49 +1,28 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
-using FixedFormPackager.Common.Extensions;
-using FixedFormPackager.Common.Models;
 using NLog;
 
 namespace AssessmentPackageBuilder.Utilities
 {
     public static class BpElementUtilities
     {
-        private const string Pattern = @"^(\w+)-\w*-v(\d):";
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static List<XElement> GetBprefs(string input)
+        public static List<XElement> GetBprefs(string input, string publisher)
         {
-            var barrierCount = input.Count(x => x.Equals('|'));
-            var pattern = Pattern;
-            for (var i = 0; i <= barrierCount; i++)
-            {
-                pattern = $"{pattern}(?>(\\w+-*\\w*)+\\|*)+";
-            }
-            pattern = pattern + "$";
-            var matches = Regex.Matches(input, pattern)
-                .Cast<Match>().ToList();
             var result = new List<XElement>();
-            if (!matches.Any() || !matches.TrueForAll(x => x.Success))
+            if (!input.Contains(":"))
             {
-                Logger.LogError(new ErrorReportItem
-                {
-                    Location = "bpref generation",
-                    Severity = LogLevel.Warn
-                }, $"Unparsable input {input} passed to bpref generator");
                 return result;
             }
-            var standard = new XElement("bpref", $"{matches.First().Groups[1]}-{matches.First().Groups[2]}");
-            result.Add(standard);
-            for (var i = 3; i < matches.First().Groups.Count; i++)
+            var sections = input.Split(':').LastOrDefault()?.Split('|');
+            for (var i = 0; i < sections.Length; i++)
             {
-                var bprefBuilder = standard.Value;
-                for (var j = 3; j <= i; j++)
-                {
-                    bprefBuilder = $"{bprefBuilder}|{matches.First().Groups[j]}";
-                }
-                result.Add(new XElement("bpref", bprefBuilder));
+                result.Add(i == 0
+                    ? new XElement("bpref", $"{publisher}-{sections[i]}")
+                    : new XElement("bpref",
+                        $"{publisher}-{sections.Take(result.Count).Aggregate((x, y) => $"{x}|{y}")}|{sections[i]}"));
             }
             return result;
         }

--- a/AssessmentPackageBuilder/Utilities/BPElementUtilities.cs
+++ b/AssessmentPackageBuilder/Utilities/BPElementUtilities.cs
@@ -1,14 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
-using NLog;
 
 namespace AssessmentPackageBuilder.Utilities
 {
     public static class BpElementUtilities
     {
-        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
-
         public static List<XElement> GetBprefs(string input, string publisher)
         {
             var result = new List<XElement>();

--- a/FixedFormPackager.Common/Models/Csv/Item.cs
+++ b/FixedFormPackager.Common/Models/Csv/Item.cs
@@ -11,6 +11,6 @@ namespace FixedFormPackager.Common.Models.Csv
         public string FormPosition { get; set; }
         public string SegmentId { get; set; }
         public string SegmentPosition { get; set; }
-        public IEnumerable<ItemScoring> ItemScoringInformation { get; set; }
+        public IEnumerable<ItemScoring> ItemScoringInformation { get; set; } = new List<ItemScoring>();
     }
 }

--- a/FixedFormPackager.Common/Utilities/ItemStimuliMapper.cs
+++ b/FixedFormPackager.Common/Utilities/ItemStimuliMapper.cs
@@ -9,7 +9,8 @@ namespace FixedFormPackager.Common.Utilities
         public static Item Map(AssessmentContent assessmentContent, Item item)
         {
             item.AssociatedStimuliId =
-                assessmentContent.MainDocument.XPathSelectElement("./itemrelease/item/associatedpassage")?.Value ?? string.Empty;
+                assessmentContent.MainDocument.XPathSelectElement("./itemrelease/item/associatedpassage")?.Value ??
+                string.Empty;
             return item;
         }
     }

--- a/FixedFormPackager/ItemRetriever/ResourceRetriever.csproj
+++ b/FixedFormPackager/ItemRetriever/ResourceRetriever.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="Utilities\ContentAccess.cs" />
     <Compile Include="GitLab\ResourceGenerator.cs" />
+    <Compile Include="Utilities\IrtMapper.cs" />
     <Compile Include="Utilities\PathHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/FixedFormPackager/ItemRetriever/Utilities/IrtMapper.cs
+++ b/FixedFormPackager/ItemRetriever/Utilities/IrtMapper.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using System.Xml.XPath;
+using FixedFormPackager.Common.Models.Csv;
+
+namespace ItemRetriever.Utilities
+{
+    public static class IrtMapper
+    {
+        public static IEnumerable<ItemScoring> RetrieveIrtParameters(string itemId)
+        {
+            var document = ContentAccess.RetrieveDocument($"Item-{itemId}");
+            var sXmlNs = new XmlNamespaceManager(new NameTable());
+            sXmlNs.AddNamespace("sa", "http://www.smarterapp.org/ns/1/assessment_item_metadata");
+            var irt = document.MetaDocument.XPathSelectElements(
+                "metadata/sa:smarterAppMetadata/sa:IrtDimension", sXmlNs);
+            return irt.Select(x => new ItemScoring
+            {
+                MeasurementModel = x.XPathSelectElement("./sa:IrtModelType", sXmlNs)?.Value,
+                Dimension = x.XPathSelectElement("./sa:IrtDimensionPurpose", sXmlNs)?.Value,
+                ScorePoints = x.XPathSelectElement("./sa:IrtScore", sXmlNs)?.Value,
+                Weight = x.XPathSelectElement("./sa:IrtWeight", sXmlNs)?.Value,
+                a = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"a\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
+                b = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
+                b0 = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b0\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
+                b1 = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b1\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
+                b2 = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b2\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
+                b3 = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b3\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
+                b4 = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b4\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
+                c = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"c\"]/sa:Value", sXmlNs)?.Value ?? string.Empty
+            });
+        }
+    }
+}

--- a/FixedFormPackager/ItemRetriever/Utilities/IrtMapper.cs
+++ b/FixedFormPackager/ItemRetriever/Utilities/IrtMapper.cs
@@ -21,14 +21,30 @@ namespace ItemRetriever.Utilities
                 Dimension = x.XPathSelectElement("./sa:IrtDimensionPurpose", sXmlNs)?.Value,
                 ScorePoints = x.XPathSelectElement("./sa:IrtScore", sXmlNs)?.Value,
                 Weight = x.XPathSelectElement("./sa:IrtWeight", sXmlNs)?.Value,
-                a = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"a\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
-                b = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
-                b0 = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b0\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
-                b1 = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b1\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
-                b2 = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b2\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
-                b3 = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b3\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
-                b4 = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b4\"]/sa:Value", sXmlNs)?.Value ?? string.Empty,
-                c = x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"c\"]/sa:Value", sXmlNs)?.Value ?? string.Empty
+                a =
+                    x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"a\"]/sa:Value", sXmlNs)?.Value ??
+                    string.Empty,
+                b =
+                    x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b\"]/sa:Value", sXmlNs)?.Value ??
+                    string.Empty,
+                b0 =
+                    x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b0\"]/sa:Value", sXmlNs)?.Value ??
+                    string.Empty,
+                b1 =
+                    x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b1\"]/sa:Value", sXmlNs)?.Value ??
+                    string.Empty,
+                b2 =
+                    x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b2\"]/sa:Value", sXmlNs)?.Value ??
+                    string.Empty,
+                b3 =
+                    x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b3\"]/sa:Value", sXmlNs)?.Value ??
+                    string.Empty,
+                b4 =
+                    x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"b4\"]/sa:Value", sXmlNs)?.Value ??
+                    string.Empty,
+                c =
+                    x.XPathSelectElement("./sa:IrtParameter[sa:Name/text() = \"c\"]/sa:Value", sXmlNs)?.Value ??
+                    string.Empty
             });
         }
     }


### PR DESCRIPTION
Fixed bug when generating bprefs. Added fallback to metadata.xml in case where item scoring parameters are not provided in the calling CSV (based on not having any valid measurement parameters)