### PR TITLE
IAT modifications

### DIFF
--- a/AssessmentPackageBuilder/Administration/AdminSegment.cs
+++ b/AssessmentPackageBuilder/Administration/AdminSegment.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
 using System.Xml.XPath;
@@ -42,10 +43,17 @@ namespace AssessmentPackageBuilder.Administration
 
         private static IEnumerable<string> GetBprefsForItemId(XNode itempool, string uniqueId)
         {
-            return
-                itempool.XPathSelectElement($"./testitem[identifier/@uniqueid='{uniqueId}']")
-                    .XPathSelectElements("./bpref")
-                    .Select(x => x.Value);
+            try
+            {
+                return
+                    itempool.XPathSelectElement($"./testitem[identifier/@uniqueid='{uniqueId}']")
+                        .XPathSelectElements("./bpref")
+                        .Select(x => x.Value);
+            }
+            catch (Exception) // If there was no metadata file provided with the items packaged, return an empty list
+            {
+                return new List<string>();
+            }
         }
     }
 }

--- a/AssessmentPackageBuilder/Common/TestBlueprint.cs
+++ b/AssessmentPackageBuilder/Common/TestBlueprint.cs
@@ -18,10 +18,10 @@ namespace AssessmentPackageBuilder.Common
             var segments =
                 bprefs.First(x => x.Key).Select(x => BpElement.Construct("segment", x.Value.ToString(), x.Key));
             var strands =
-                bprefs.First(x => !x.Key)
+                bprefs.FirstOrDefault(x => !x.Key)?
                     .Where(x => !x.Key.Contains('|'))
                     .Select(x => BpElement.Construct("strand", x.Value.ToString(), x.Key));
-            var contentLevels = bprefs.First(x => !x.Key)
+            var contentLevels = bprefs.FirstOrDefault(x => !x.Key)?
                 .Where(x => x.Key.Contains('|'))
                 .Select(x => BpElement.Construct("contentlevel", x.Value.ToString(), x.Key));
             result.Add(BpElement.Construct("test", bprefs.First(x => x.Key).Sum(x => x.Value).ToString(), assessmentId));

--- a/FixedFormPackager.Common/Models/AssessmentContent.cs
+++ b/FixedFormPackager.Common/Models/AssessmentContent.cs
@@ -4,12 +4,6 @@ namespace FixedFormPackager.Common.Models
 {
     public class AssessmentContent
     {
-        public AssessmentContent()
-        {
-            MainDocument = new XDocument();
-            MetaDocument = new XDocument();
-        }
-
         public XDocument MainDocument { get; set; }
         public XDocument MetaDocument { get; set; }
         public string BasePath { get; set; }

--- a/FixedFormPackager/ItemRetriever/GitLab/ResourceGenerator.cs
+++ b/FixedFormPackager/ItemRetriever/GitLab/ResourceGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using System.Linq;
@@ -6,6 +7,7 @@ using FixedFormPackager.Common.Extensions;
 using FixedFormPackager.Common.Models;
 using ItemRetriever.Utilities;
 using LibGit2Sharp;
+using LibGit2Sharp.Handlers;
 using NLog;
 
 namespace ItemRetriever.GitLab
@@ -14,14 +16,14 @@ namespace ItemRetriever.GitLab
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        public static void Retrieve(GitLabInfo gitLabInfo, string identifier)
+        public static string Retrieve(GitLabInfo gitLabInfo, string identifier)
         {
             var cloneOptions = new CloneOptions
             {
                 CredentialsProvider = (url, user, cred) =>
                     GenerateCredentials(gitLabInfo)
             };
-
+            var remoteRepoPath = GenerateValidRemoteRepositoryPath(gitLabInfo, identifier);
             var resourcePath = PathHelper.RetrievePathForId(identifier);
             if (!Directory.Exists(resourcePath))
             {
@@ -31,35 +33,70 @@ namespace ItemRetriever.GitLab
                     Type = identifier.Contains("Item") ? "Item" : "Stimulus",
                     UniqueId = identifier
                 }, $"Local repository not found. Cloning {resourcePath.Split('\\').LastOrDefault() ?? string.Empty}");
-                Repository.Clone(
-                    $"{gitLabInfo.BaseUrl}{gitLabInfo.Group}/{identifier}.git",
-                    resourcePath, cloneOptions);
+                Repository.Clone(remoteRepoPath, resourcePath, cloneOptions);
+                return remoteRepoPath;
             }
-            else
+            using (var repository = new Repository(resourcePath))
             {
-                using (var repository = new Repository(resourcePath))
+                var pullOptions = new PullOptions
                 {
-                    var pullOptions = new PullOptions
+                    FetchOptions = new FetchOptions
                     {
-                        FetchOptions = new FetchOptions
-                        {
-                            CredentialsProvider = (url, user, cred) =>
-                                GenerateCredentials(gitLabInfo)
-                        }
-                    };
-                    Logger.LogInfo(new ProcessingReportItem
-                    {
-                        Destination = resourcePath,
-                        Type = identifier.Contains("Item") ? "Item" : "Stimulus",
-                        UniqueId = identifier
-                    }, $"Local repository found. Pulling {resourcePath.Split('\\').LastOrDefault() ?? string.Empty}");
-                    Commands.Pull(repository,
-                        new Signature(new Identity(
-                                ConfigurationManager.AppSettings["userName"],
-                                ConfigurationManager.AppSettings["userEmail"])
-                            , DateTimeOffset.Now), pullOptions);
-                }
+                        CredentialsProvider = (url, user, cred) =>
+                            GenerateCredentials(gitLabInfo)
+                    }
+                };
+                Logger.LogInfo(new ProcessingReportItem
+                {
+                    Destination = resourcePath,
+                    Type = identifier.Contains("Item") ? "Item" : "Stimulus",
+                    UniqueId = identifier
+                }, $"Local repository found. Pulling {resourcePath.Split('\\').LastOrDefault() ?? string.Empty}");
+                Commands.Pull(repository,
+                    new Signature(new Identity(
+                            ConfigurationManager.AppSettings["userName"],
+                            ConfigurationManager.AppSettings["userEmail"])
+                        , DateTimeOffset.Now), pullOptions);
             }
+            return remoteRepoPath.Split('/').LastOrDefault()?.Replace(".git", string.Empty);
+        }
+
+        private static string GenerateValidRemoteRepositoryPath(GitLabInfo gitLabInfo, string identifier)
+        {
+            string locationBase = $"{gitLabInfo.BaseUrl}{gitLabInfo.Group}";
+            const string defaultBankKey = "187";
+            switch (identifier.Count(x => x == '-'))
+            {
+                case 0: // This is missing both the bank key and the 'Item-' prefix - add both
+                    identifier = $"Item-{defaultBankKey}-{identifier}";
+                    break;
+                case 1: // This is missing the bank key - we add the default
+                    identifier = $"Item-{defaultBankKey}-{identifier.Split('-').Last()}";
+                    break;
+                case 2: // This is the expected format. We do nothing
+                    break;
+                default: // This  is an error
+                    return null;
+            }
+               var potentialItemFormats = new Dictionary<string, string>
+            {
+                {"SBAC content package format", $"{locationBase}/{identifier}.git" },
+                {"IAT item format", $"{locationBase}/{identifier.Split('-').LastOrDefault() ?? string.Empty}.git" },
+                {"No bank key", $"{locationBase}/Item-{identifier.Split('-').LastOrDefault() ?? string.Empty}.git" }
+            };
+            return potentialItemFormats.Values.FirstOrDefault(x =>
+            {
+                try
+                {
+                    Repository.ListRemoteReferences(x, (url, user, cred) =>
+                        GenerateCredentials(gitLabInfo));
+                    return true;
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            });
         }
 
         private static UsernamePasswordCredentials GenerateCredentials(GitLabInfo gitLabInfo)

--- a/FixedFormPackager/ItemRetriever/Utilities/ContentAccess.cs
+++ b/FixedFormPackager/ItemRetriever/Utilities/ContentAccess.cs
@@ -1,11 +1,15 @@
 ﻿using System.IO;
 using System.Xml.Linq;
+using FixedFormPackager.Common.Extensions;
 using FixedFormPackager.Common.Models;
+using NLog;
 
 namespace ItemRetriever.Utilities
 {
     public static class ContentAccess
     {
+
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
         public static AssessmentContent RetrieveDocument(string identifier)
         {
             var content = new AssessmentContent();
@@ -15,7 +19,19 @@ namespace ItemRetriever.Utilities
                 throw new IOException($"Expected content directory at {basePath} does not exist");
             }
             content.MainDocument = XDocument.Load($"{basePath}/{identifier.ToLower()}.xml");
-            content.MetaDocument = XDocument.Load($"{basePath}/metadata.xml");
+            try
+            {
+                content.MetaDocument = XDocument.Load($"{basePath}/metadata.xml");
+            }
+            catch (IOException)
+            {
+                Logger.LogError(new ErrorReportItem
+                {
+                    Location = "Retrieve Document metadata.xml",
+                    Severity = LogLevel.Warn
+                },
+                "Retrieved item does not contain a metadata.xml file!");
+            }
             content.BasePath = basePath;
             return content;
         }

--- a/FixedFormPackager/ItemRetriever/Utilities/IrtMapper.cs
+++ b/FixedFormPackager/ItemRetriever/Utilities/IrtMapper.cs
@@ -11,6 +11,10 @@ namespace ItemRetriever.Utilities
         public static IEnumerable<ItemScoring> RetrieveIrtParameters(string itemId)
         {
             var document = ContentAccess.RetrieveDocument($"Item-{itemId}");
+            if (document.MetaDocument == null)
+            {
+                return new List<ItemScoring>();
+            }
             var sXmlNs = new XmlNamespaceManager(new NameTable());
             sXmlNs.AddNamespace("sa", "http://www.smarterapp.org/ns/1/assessment_item_metadata");
             var irt = document.MetaDocument.XPathSelectElements(


### PR DESCRIPTION
These modifications were made to support the IAT project. They provide a more defensive approach to packaging - allowing for some naming mismatches and the absence of the metadata.xml file. NOTE: items without a metadata file do not allow the packager to properly generate blueprints!